### PR TITLE
Adds Cache tools to your requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ fastembed
 langchain_community # In theory removable with enough manual implementation
 langchain_groq
 numpy # Solely used for typing. If there is a way to keep the type enforcement but remove this, that'd be preferred.
+cachetools


### PR DESCRIPTION
If you don't have it this happens:

Traceback (most recent call last):
  File "C:\Users\NAME\Downloads\discord-rag-chatbot-main\main.py", line 10, in <module>
    from src.messages import *
  File "C:\Users\NAME\Downloads\discord-rag-chatbot-main\src\messages.py", line 8, in <module>
    from src.components.cache import Cache
  File "C:\Users\NAME\Downloads\discord-rag-chatbot-main\src\components\cache.py", line 1, in <module>
    from cachetools import TTLCache
ModuleNotFoundError: No module named 'cachetools'
